### PR TITLE
Add description to fetch descriptions for resources + fields

### DIFF
--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -160,6 +160,7 @@ type Schema struct {
 	XAEPFieldNumbers map[int]string `json:"x-aep-field-numbers,omitempty"`
 	ReadOnly         bool           `json:"readOnly,omitempty"`
 	Required         []string       `json:"required,omitempty"`
+	Description      string         `json:"description,omitempty"`
 }
 
 type Properties map[string]Schema


### PR DESCRIPTION
Descriptions and fields have Markdown descriptions that are defined in the Schema object. This is useful for Terraform, where these descriptions define the documentation for the provider.