### PR TITLE
pattern may not have a leading slash

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -313,7 +313,7 @@ func getOrPopulateResource(singular string, pattern []string, s *openapi.Schema,
 			Plural:       s.XAEPResource.Plural,
 			Parents:      parents,
 			Children:     []*Resource{},
-			PatternElems: strings.Split(s.XAEPResource.Patterns[0], "/")[1:],
+			PatternElems: strings.Split(strings.TrimPrefix(s.XAEPResource.Patterns[0], "/"), "/"),
 			Schema:       s,
 		}
 	} else {


### PR DESCRIPTION
If the pattern doesn't have a leading slash, the first real element will be removed. This makes it impossible to assemble the full path.