### PR TITLE
Methods for sending HTTP requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,12 @@ module github.com/aep-dev/aep-lib-go
 go 1.22.3
 
 require (
+	github.com/jarcoal/httpmock v1.3.1
+	github.com/stretchr/testify v1.9.0
+)
+
+require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,14 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
+github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
+github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
+github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -106,6 +106,12 @@ func parseResponse(resp *http.Response) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %v", err)
 	}
+
+	// Empty response means no errors.
+	if len(respBody) == 0 {
+		return map[string]interface{}{}, nil
+	}
+
 	var data map[string]interface{}
 	err = json.Unmarshal(respBody, &data)
 	if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,139 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/aep-dev/aep-lib-go/pkg/api"
+)
+
+func Create(ctx context.Context, r *api.Resource, c *http.Client, serverUrl string, body map[string]interface{}, parameters map[string]string) (map[string]interface{}, error) {
+	suffix := ""
+	if r.CreateMethod != nil && r.CreateMethod.SupportsUserSettableCreate {
+		id, ok := body["id"]
+		if !ok {
+			return nil, fmt.Errorf("id field not found in %v", body)
+		}
+		idString, ok := id.(string)
+		if !ok {
+			return nil, fmt.Errorf("id field is not string %v", id)
+		}
+
+		suffix = fmt.Sprintf("?id=%s", idString)
+	}
+	url := createBase(ctx, r, serverUrl, parameters, suffix)
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling JSON: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", url, strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return nil, fmt.Errorf("error creating post request: %v", err)
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %v", err)
+	}
+	var data map[string]interface{}
+	err = json.Unmarshal(respBody, &data)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func Read(ctx context.Context, c *http.Client, serverUrl string, path string) (map[string]interface{}, error) {
+	url := fmt.Sprintf("%s/%s", serverUrl, strings.TrimPrefix(path, "/"))
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating post request: %v", err)
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var data map[string]interface{}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %v", err)
+	}
+
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling JSON: %v", err)
+	}
+
+	return data, nil
+}
+
+func Delete(ctx context.Context, c *http.Client, serverUrl string, path string) error {
+	url := fmt.Sprintf("%s/%s", serverUrl, strings.TrimPrefix(path, "/"))
+
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return fmt.Errorf("error creating delete request: %v", err)
+	}
+
+	_, err = c.Do(req)
+	return err
+}
+
+func Update(ctx context.Context, c *http.Client, serverUrl string, path string, body map[string]interface{}) error {
+	url := fmt.Sprintf("%s/%s", serverUrl, strings.TrimPrefix(path, "/"))
+
+	reqBody, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("error marshalling JSON for request body: %v", err)
+	}
+
+	req, err := http.NewRequest("PATCH", url, strings.NewReader(string(reqBody)))
+	if err != nil {
+		return fmt.Errorf("error creating delete request: %v", err)
+	}
+
+	_, err = c.Do(req)
+	return err
+}
+
+func createBase(ctx context.Context, r *api.Resource, serverUrl string, parameters map[string]string, suffix string) string {
+	serverUrl = strings.TrimSuffix(serverUrl, "/")
+	urlElems := []string{serverUrl}
+	for i, elem := range r.PatternElems {
+		if i == len(r.PatternElems)-1 {
+			continue
+		}
+
+		if i%2 == 0 {
+			urlElems = append(urlElems, elem)
+		} else {
+			paramName := elem[1 : len(elem)-1]
+			if value, ok := parameters[paramName]; ok {
+				if strings.Contains(value, "/") {
+					value = strings.Split(value, "/")[len(strings.Split(value, "/"))-1]
+				}
+				urlElems = append(urlElems, value)
+			}
+		}
+	}
+	result := strings.Join(urlElems, "/")
+	if suffix != "" {
+		result = result + suffix
+	}
+	return result
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,146 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/aep-dev/aep-lib-go/pkg/api"
+	"github.com/jarcoal/httpmock"
+)
+
+func TestCreate(t *testing.T) {
+	// Create a test server
+	httpmock.Activate()
+	httpmock.RegisterResponder("POST", "http://localhost:8081/publishers/my-pub/books",
+		httpmock.NewStringResponder(200, "{\"path\":\"/publishers/my-pub/books/1\"}"))
+
+	// Create a test resource
+	r := &api.Resource{
+		CreateMethod: &api.CreateMethod{
+			SupportsUserSettableCreate: false,
+		},
+		PatternElems: []string{"publishers", "{publisher}", "books", "{book}"},
+	}
+
+	// Create a test context
+	ctx := context.Background()
+
+	// Create a test body
+	body := map[string]interface{}{
+		"price": "1",
+	}
+
+	parameters := map[string]string{
+		"publisher": "my-pub",
+	}
+
+	// Call the Create method
+	data, err := Create(ctx, r, http.DefaultClient, "http://localhost:8081/", body, parameters)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check the response
+	if data["path"] != "/publishers/my-pub/books/1" {
+		t.Errorf("expected id to be '/publishers/my-pub/books/1', got '%v'", data["path"])
+	}
+}
+
+func TestCreateWithUserSpecifiedId(t *testing.T) {
+	// Create a test server
+	httpmock.Activate()
+	httpmock.RegisterResponder("POST", "http://localhost:8081/publishers/my-pub/books?id=my-book",
+		httpmock.NewStringResponder(200, "{\"path\":\"/publishers/my-pub/books/my-book\"}"))
+
+	// Create a test resource
+	r := &api.Resource{
+		CreateMethod: &api.CreateMethod{
+			SupportsUserSettableCreate: true,
+		},
+		PatternElems: []string{"publishers", "{publisher}", "books", "{book}"},
+	}
+
+	// Create a test context
+	ctx := context.Background()
+
+	// Create a test body
+	body := map[string]interface{}{
+		"price": "1",
+		"id":    "my-book",
+	}
+
+	parameters := map[string]string{
+		"publisher": "my-pub",
+	}
+
+	// Call the Create method
+	data, err := Create(ctx, r, http.DefaultClient, "http://localhost:8081/", body, parameters)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check the response
+	if data["path"] != "/publishers/my-pub/books/my-book" {
+		t.Errorf("expected id to be '/publishers/my-pub/books/my-book', got '%v'", data["path"])
+	}
+}
+
+func TestGet(t *testing.T) {
+	// Create a test server
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", "http://localhost:8081/publishers/my-pub/books/1",
+		httpmock.NewStringResponder(200, "{\"path\":\"/publishers/my-pub/books/1\"}"))
+
+	// Create a test context
+	ctx := context.Background()
+
+	// Call the Read method
+	data, err := Read(ctx, http.DefaultClient, "http://localhost:8081", "/publishers/my-pub/books/1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check the response
+	if data["path"] != "/publishers/my-pub/books/1" {
+		t.Errorf("expected id to be '/publishers/my-pub/books/1', got '%v'", data["path"])
+	}
+}
+
+func TestDelete(t *testing.T) {
+	// Create a test server
+	httpmock.Activate()
+	httpmock.RegisterResponder("DELETE", "http://localhost:8081/publishers/my-pub/books/1",
+		httpmock.NewStringResponder(200, ""))
+
+	// Create a test context
+	ctx := context.Background()
+
+	// Call the Delete method
+	err := Delete(ctx, http.DefaultClient, "http://localhost:8081", "/publishers/my-pub/books/1")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	// Create a test server
+	httpmock.Activate()
+	httpmock.RegisterResponder("PATCH", "http://localhost:8081/publishers/my-pub/books/1",
+		httpmock.NewStringResponder(200, "{\"path\":\"/publishers/my-pub/books/1\", \"price\":\"2\"}"))
+
+	// Create a test context
+	ctx := context.Background()
+
+	// Create a test body
+	body := map[string]interface{}{
+		"path":  "/publishers/my-pub/books/1",
+		"price": "2",
+	}
+
+	// Call the Update method
+	err := Update(ctx, http.DefaultClient, "http://localhost:8081", "/publishers/my-pub/books/1", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -96,7 +96,7 @@ func TestGet(t *testing.T) {
 	ctx := context.Background()
 
 	// Call the Read method
-	data, err := Read(ctx, http.DefaultClient, "http://localhost:8081", "/publishers/my-pub/books/1")
+	data, err := Get(ctx, http.DefaultClient, "http://localhost:8081", "/publishers/my-pub/books/1")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is the same client logic that we're using in the Terraform provider. Ideally, we'd like to have the CLI share this client logic, so that we can share improvements between the CLI and Terraform.

This is a first pass. It's still missing:

* List method (with pagination)
* LROs.