### PR TITLE
Add Client struct for HTTP methods

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -13,12 +13,12 @@ import (
 
 type Client struct {
 	Headers map[string]string
-	c       *http.Client
+	client  *http.Client
 }
 
 func NewClient(c *http.Client) *Client {
 	return &Client{
-		c:       c,
+		client:  c,
 		Headers: make(map[string]string),
 	}
 }
@@ -50,7 +50,7 @@ func (c *Client) Create(ctx context.Context, r *api.Resource, serverUrl string, 
 		return nil, fmt.Errorf("error creating POST request: %v", err)
 	}
 
-	resp, err := c.c.Do(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (c *Client) Get(ctx context.Context, serverUrl string, path string) (map[st
 		return nil, fmt.Errorf("error creating GET request: %v", err)
 	}
 
-	resp, err := c.c.Do(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (c *Client) Delete(ctx context.Context, serverUrl string, path string) erro
 		return fmt.Errorf("error creating DELETE request: %v", err)
 	}
 
-	resp, err := c.c.Do(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func (c *Client) Update(ctx context.Context, serverUrl string, path string, body
 		return fmt.Errorf("error creating PATCH request: %v", err)
 	}
 
-	resp, err := c.c.Do(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -77,7 +77,8 @@ func TestCreateWithUserSpecifiedId(t *testing.T) {
 	}
 
 	// Call the Create method
-	data, err := Create(ctx, r, http.DefaultClient, "http://localhost:8081/", body, parameters)
+	c := NewClient(http.DefaultClient)
+	data, err := c.Create(ctx, r, "http://localhost:8081/", body, parameters)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +99,8 @@ func TestGet(t *testing.T) {
 	ctx := context.Background()
 
 	// Call the Read method
-	data, err := Get(ctx, http.DefaultClient, "http://localhost:8081", "/publishers/my-pub/books/1")
+	c := NewClient(http.DefaultClient)
+	data, err := c.Get(ctx, "http://localhost:8081", "/publishers/my-pub/books/1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +121,8 @@ func TestDelete(t *testing.T) {
 	ctx := context.Background()
 
 	// Call the Delete method
-	err := Delete(ctx, http.DefaultClient, "http://localhost:8081", "/publishers/my-pub/books/1")
+	c := NewClient(http.DefaultClient)
+	err := c.Delete(ctx, "http://localhost:8081", "/publishers/my-pub/books/1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +144,8 @@ func TestUpdate(t *testing.T) {
 	}
 
 	// Call the Update method
-	err := Update(ctx, http.DefaultClient, "http://localhost:8081", "/publishers/my-pub/books/1", body)
+	c := NewClient(http.DefaultClient)
+	err := c.Update(ctx, "http://localhost:8081", "/publishers/my-pub/books/1", body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -35,8 +35,10 @@ func TestCreate(t *testing.T) {
 		"publisher": "my-pub",
 	}
 
+	c := NewClient(http.DefaultClient)
+
 	// Call the Create method
-	data, err := Create(ctx, r, http.DefaultClient, "http://localhost:8081/", body, parameters)
+	data, err := c.Create(ctx, r, "http://localhost:8081/", body, parameters)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This adds a Client that stores a http.Client and the Headers. I'm also open to having it store the serverUrl as well.

The hope is that the Client can be created once and then passed around to abstract away the http.Client + Headers.