### PR TITLE
Add logging function to client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aep-dev/aep-lib-go/pkg/api"
 )
 
-type LoggingFunction func(ctx context.Context, message string)
+type LoggingFunction func(ctx context.Context, message string, args ...any)
 
 type Client struct {
 	Headers         map[string]string
@@ -21,9 +21,10 @@ type Client struct {
 
 func NewClient(c *http.Client) *Client {
 	return &Client{
-		client:          c,
-		Headers:         make(map[string]string),
-		LoggingFunction: func(ctx context.Context, message string) {},
+		client:  c,
+		Headers: make(map[string]string),
+		// The basic logging function does not do anything.
+		LoggingFunction: func(ctx context.Context, message string, args ...any) {},
 	}
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,15 +11,19 @@ import (
 	"github.com/aep-dev/aep-lib-go/pkg/api"
 )
 
+type LoggingFunction func(ctx context.Context, message string)
+
 type Client struct {
-	Headers map[string]string
-	client  *http.Client
+	Headers         map[string]string
+	client          *http.Client
+	LoggingFunction LoggingFunction
 }
 
 func NewClient(c *http.Client) *Client {
 	return &Client{
-		client:  c,
-		Headers: make(map[string]string),
+		client:          c,
+		Headers:         make(map[string]string),
+		LoggingFunction: func(ctx context.Context, message string) {},
 	}
 }
 
@@ -45,7 +49,7 @@ func (c *Client) Create(ctx context.Context, r *api.Resource, serverUrl string, 
 		return nil, fmt.Errorf("error marshalling JSON: %v", err)
 	}
 
-	req, err := c.newRequest("POST", url, strings.NewReader(string(jsonBody)))
+	req, err := c.newRequest(ctx, "POST", url, strings.NewReader(string(jsonBody)))
 	if err != nil {
 		return nil, fmt.Errorf("error creating POST request: %v", err)
 	}
@@ -54,13 +58,13 @@ func (c *Client) Create(ctx context.Context, r *api.Resource, serverUrl string, 
 	if err != nil {
 		return nil, err
 	}
-	return parseResponse(resp)
+	return c.parseResponse(ctx, resp)
 }
 
 func (c *Client) Get(ctx context.Context, serverUrl string, path string) (map[string]interface{}, error) {
 	url := fmt.Sprintf("%s/%s", serverUrl, strings.TrimPrefix(path, "/"))
 
-	req, err := c.newRequest("GET", url, nil)
+	req, err := c.newRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating GET request: %v", err)
 	}
@@ -70,13 +74,13 @@ func (c *Client) Get(ctx context.Context, serverUrl string, path string) (map[st
 		return nil, err
 	}
 
-	return parseResponse(resp)
+	return c.parseResponse(ctx, resp)
 }
 
 func (c *Client) Delete(ctx context.Context, serverUrl string, path string) error {
 	url := fmt.Sprintf("%s/%s", serverUrl, strings.TrimPrefix(path, "/"))
 
-	req, err := c.newRequest("DELETE", url, nil)
+	req, err := c.newRequest(ctx, "DELETE", url, nil)
 	if err != nil {
 		return fmt.Errorf("error creating DELETE request: %v", err)
 	}
@@ -86,7 +90,7 @@ func (c *Client) Delete(ctx context.Context, serverUrl string, path string) erro
 		return err
 	}
 
-	_, err = parseResponse(resp)
+	_, err = c.parseResponse(ctx, resp)
 	return err
 }
 
@@ -98,7 +102,7 @@ func (c *Client) Update(ctx context.Context, serverUrl string, path string, body
 		return fmt.Errorf("error marshalling JSON for request body: %v", err)
 	}
 
-	req, err := c.newRequest("PATCH", url, strings.NewReader(string(reqBody)))
+	req, err := c.newRequest(ctx, "PATCH", url, strings.NewReader(string(reqBody)))
 	if err != nil {
 		return fmt.Errorf("error creating PATCH request: %v", err)
 	}
@@ -108,11 +112,11 @@ func (c *Client) Update(ctx context.Context, serverUrl string, path string, body
 		return err
 	}
 
-	_, err = parseResponse(resp)
+	_, err = c.parseResponse(ctx, resp)
 	return err
 }
 
-func (c *Client) newRequest(method string, url string, body io.Reader) (*http.Request, error) {
+func (c *Client) newRequest(ctx context.Context, method string, url string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, fmt.Errorf("error creating %s request: %v", method, err)
@@ -120,15 +124,18 @@ func (c *Client) newRequest(method string, url string, body io.Reader) (*http.Re
 	for key, value := range c.Headers {
 		req.Header.Set(key, value)
 	}
+	c.LoggingFunction(ctx, fmt.Sprintf("Sending %s request to %s with body %v", method, url, body))
 	return req, nil
 }
 
-func parseResponse(resp *http.Response) (map[string]interface{}, error) {
+func (c *Client) parseResponse(ctx context.Context, resp *http.Response) (map[string]interface{}, error) {
 	defer resp.Body.Close()
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %v", err)
 	}
+
+	c.LoggingFunction(ctx, fmt.Sprintf("Received response %s", string(respBody)))
 
 	// Empty response means no errors.
 	if len(respBody) == 0 {


### PR DESCRIPTION
We need a way to log requests + responses. Terraform does logging in a strange way, so the best path is to include a (optional) function that handles logging.