### PR TITLE
fix(oas, path): add _id suffix

### DIFF
--- a/examples/resource-definitions/bookstore.yaml
+++ b/examples/resource-definitions/bookstore.yaml
@@ -77,9 +77,9 @@ resources:
           properties:
             success:
               type: boolean
-  book-edition:
-    singular: "book-edition"
-    plural: "book-editions"
+  book_edition:
+    singular: "book_edition"
+    plural: "book_editions"
     parents: ["book"]
     schema:
       type: object

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -203,7 +203,7 @@ func GetAPI(api *openapi.OpenAPI, serverURL, pathPrefix string) (*API, error) {
 			if err != nil {
 				return nil, fmt.Errorf("error dereferencing schema %q: %v", sRef.Ref, err)
 			}
-			singular := cases.PascalCaseToKebabCase(key)
+			singular := cases.PascalToSnakeCase(key)
 			pattern := strings.Split(path, "/")[1:]
 			if !p.IsResourcePattern {
 				// deduplicate the singular, if applicable
@@ -213,10 +213,10 @@ func GetAPI(api *openapi.OpenAPI, serverURL, pathPrefix string) (*API, error) {
 					parent = pattern[len(pattern)-3]
 					parent = parent[0 : len(parent)-1] // strip curly surrounding
 					if strings.HasPrefix(singular, parent) {
-						finalSingular = strings.TrimPrefix(singular, parent+"-")
+						finalSingular = strings.TrimPrefix(singular, parent+"_")
 					}
 				}
-				pattern = append(pattern, fmt.Sprintf("{%s}", finalSingular))
+				pattern = append(pattern, fmt.Sprintf("{%s_id}", finalSingular))
 			}
 			r2, err := getOrPopulateResource(singular, pattern, dereferencedSchema, resourceBySingular, api)
 			if err != nil {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -58,7 +58,7 @@ var basicOpenAPI = &openapi.OpenAPI{
 				},
 			},
 		},
-		"/widgets/{widget}": {
+		"/widgets/{widget_id}": {
 			Get: &openapi.Operation{
 				Responses: map[string]openapi.Response{
 					"200": {
@@ -87,7 +87,7 @@ var basicOpenAPI = &openapi.OpenAPI{
 				},
 			},
 		},
-		"/widgets/{widget}:start": {
+		"/widgets/{widget_id}:start": {
 			Post: &openapi.Operation{
 				RequestBody: &openapi.RequestBody{
 					Content: map[string]openapi.MediaType{
@@ -121,7 +121,7 @@ var basicOpenAPI = &openapi.OpenAPI{
 				},
 			},
 		},
-		"/widgets/{widget}:stop": {
+		"/widgets/{widget_id}:stop": {
 			Post: &openapi.Operation{
 				RequestBody: &openapi.RequestBody{
 					Content: map[string]openapi.MediaType{
@@ -180,7 +180,7 @@ func TestGetAPI(t *testing.T) {
 
 				widget, ok := sd.Resources["widget"]
 				assert.True(t, ok, "widget resource should exist")
-				assert.Equal(t, widget.PatternElems(), []string{"widgets", "{widget}"})
+				assert.Equal(t, widget.PatternElems(), []string{"widgets", "{widget_id}"})
 				assert.Equal(t, sd.ServerURL, "https://api.example.com")
 				assert.NotNil(t, widget.Methods.Get, "should have GET method")
 				assert.NotNil(t, widget.Methods.List, "should have LIST method")
@@ -213,7 +213,7 @@ func TestGetAPI(t *testing.T) {
 			api: &openapi.OpenAPI{
 				OpenAPI: "3.1.0",
 				Paths: map[string]*openapi.PathItem{
-					"/widgets/{widget}": {
+					"/widgets/{widget_id}": {
 						Get: &openapi.Operation{
 							Responses: map[string]openapi.Response{
 								"200": {
@@ -240,7 +240,7 @@ func TestGetAPI(t *testing.T) {
 							XAEPResource: &openapi.XAEPResource{
 								Singular: "widget",
 								Plural:   "widgets",
-								Patterns: []string{"/widgets/{widget}"},
+								Patterns: []string{"/widgets/{widget_id}"},
 							},
 						},
 					},
@@ -251,7 +251,7 @@ func TestGetAPI(t *testing.T) {
 				assert.True(t, ok, "widget resource should exist")
 				assert.Equal(t, "widget", widget.Singular)
 				assert.Equal(t, "widgets", widget.Plural)
-				assert.Equal(t, []string{"widgets", "{widget}"}, widget.PatternElems())
+				assert.Equal(t, []string{"widgets", "{widget_id}"}, widget.PatternElems())
 			},
 		},
 		{
@@ -308,7 +308,7 @@ func TestGetAPI(t *testing.T) {
 				Swagger: "2.0",
 				Servers: []openapi.Server{{URL: "https://api.example.com"}},
 				Paths: map[string]*openapi.PathItem{
-					"/widgets/{widget}": {
+					"/widgets/{widget_id}": {
 						Get: &openapi.Operation{
 							Responses: map[string]openapi.Response{
 								"200": {
@@ -333,7 +333,7 @@ func TestGetAPI(t *testing.T) {
 				widget, ok := sd.Resources["widget"]
 				assert.True(t, ok, "widget resource should exist")
 				assert.NotNil(t, widget.Methods.Get, "should have GET method")
-				assert.Equal(t, []string{"widgets", "{widget}"}, widget.PatternElems())
+				assert.Equal(t, []string{"widgets", "{widget_id}"}, widget.PatternElems())
 			},
 		},
 		{
@@ -442,7 +442,7 @@ func TestGetAPI(t *testing.T) {
 							},
 						},
 					},
-					"/widgets/{widget}": {
+					"/widgets/{widget_id}": {
 						Get: &openapi.Operation{
 							Responses: map[string]openapi.Response{
 								"200": {
@@ -486,7 +486,7 @@ func TestGetAPI(t *testing.T) {
 							},
 						},
 					},
-					"/widgets/{widget}:customOp": {
+					"/widgets/{widget_id}:customOp": {
 						Post: &openapi.Operation{
 							XAEPLongRunningOperation: &openapi.XAEPLongRunningOperation{
 								Response: openapi.XAEPLongRunningOperationResponse{
@@ -603,7 +603,7 @@ func TestLoadFromJsonBookstore(t *testing.T) {
 	assert.NotEmpty(t, apiResult.Resources, "Resources map should be populated")
 	assert.Contains(t, apiResult.Resources, "publisher", "Resources map should contain 'publisher'")
 	assert.Contains(t, apiResult.Resources, "book", "Resources map should contain 'book'")
-	assert.Contains(t, apiResult.Resources, "book-edition", "Resources map should contain 'book-edition'")
+	assert.Contains(t, apiResult.Resources, "book_edition", "Resources map should contain 'book-edition'")
 	assert.Contains(t, apiResult.Resources, "isbn", "Resources map should contain 'isbn'")
 
 	// Check some details of a resource

--- a/pkg/api/loader.go
+++ b/pkg/api/loader.go
@@ -3,10 +3,13 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/aep-dev/aep-lib-go/pkg/constants"
 	"github.com/aep-dev/aep-lib-go/pkg/openapi"
 )
+
+var singularPluralRegex = regexp.MustCompile("^[a-z][a-z0-9_]*[a-z0-9]$")
 
 func LoadAPIFromJson(data []byte) (*API, error) {
 	api := &API{}
@@ -25,7 +28,16 @@ func LoadAPIFromJson(data []byte) (*API, error) {
 // such as the "path" variable in the resource.
 func AddImplicitFieldsAndValidate(api *API) error {
 	// add the path variable to the resource
-	for _, r := range api.Resources {
+	for name, r := range api.Resources {
+		if !singularPluralRegex.MatchString(name) {
+			return fmt.Errorf("resource name %s does not match the regex %s", name, singularPluralRegex.String())
+		}
+		if !singularPluralRegex.MatchString(r.Singular) {
+			return fmt.Errorf("singular resource name %s does not match the regex %s", r.Singular, singularPluralRegex.String())
+		}
+		if !singularPluralRegex.MatchString(r.Plural) {
+			return fmt.Errorf("plural resource name %s does not match the regex %s", r.Plural, singularPluralRegex.String())
+		}
 		r.API = api
 		if r.Schema.Properties == nil {
 			r.Schema.Properties = make(map[string]openapi.Schema)

--- a/pkg/api/openapi_test.go
+++ b/pkg/api/openapi_test.go
@@ -26,9 +26,9 @@ func TestToOpenAPI(t *testing.T) {
 			api:  exampleAPI,
 			expectedPaths: []string{
 				"/publishers",
-				"/publishers/{publisher}",
-				"/publishers/{publisher}/books",
-				"/publishers/{publisher}/books/{book}",
+				"/publishers/{publisher_id}",
+				"/publishers/{publisher_id}/books",
+				"/publishers/{publisher_id}/books/{book_id}",
 			},
 			expectedSchemas: []string{
 				"account",
@@ -42,12 +42,12 @@ func TestToOpenAPI(t *testing.T) {
 						OperationID: "CreatePublisher",
 					},
 				},
-				"/publishers/{publisher}": {
+				"/publishers/{publisher_id}": {
 					Get: &openapi.Operation{
 						OperationID: "GetPublisher",
 					},
 				},
-				"/publishers/{publisher}/books": {
+				"/publishers/{publisher_id}/books": {
 					Get: &openapi.Operation{
 						OperationID: "ListBook",
 						Parameters: []openapi.Parameter{
@@ -112,7 +112,7 @@ func TestToOpenAPI(t *testing.T) {
 						},
 					},
 				},
-				"/publishers/{publisher}/books/{book}": {
+				"/publishers/{publisher_id}/books/{book_id}": {
 					Get: &openapi.Operation{
 						OperationID: "GetBook",
 					},
@@ -145,7 +145,7 @@ func TestToOpenAPI(t *testing.T) {
 						OperationID: "DeleteBook",
 					},
 				},
-				"/publishers/{publisher}/books/{book}:archive": {
+				"/publishers/{publisher_id}/books/{book_id}:archive": {
 					Post: &openapi.Operation{
 						OperationID: ":ArchiveBook",
 						RequestBody: &openapi.RequestBody{
@@ -181,7 +181,7 @@ func TestToOpenAPI(t *testing.T) {
 				},
 			},
 			expectedListSchemas: map[string]*openapi.Schema{
-				"/publishers/{publisher}/books": {
+				"/publishers/{publisher_id}/books": {
 					Type: "object",
 					Properties: map[string]openapi.Schema{
 						"unreachable": {
@@ -199,19 +199,19 @@ func TestToOpenAPI(t *testing.T) {
 			name: "book edition",
 			api:  exampleAPI,
 			expectedPaths: []string{
-				"/publishers/{publisher}/books/{book}/editions",
-				"/publishers/{publisher}/books/{book}/editions/{book-edition}",
+				"/publishers/{publisher_id}/books/{book_id}/editions",
+				"/publishers/{publisher_id}/books/{book_id}/editions/{book_edition_id}",
 			},
 			expectedSchemas: []string{
 				"account",
 			},
 			expectedOperations: map[string]openapi.PathItem{
-				"/publishers/{publisher}/books/{book}/editions": {
+				"/publishers/{publisher_id}/books/{book_id}/editions": {
 					Get: &openapi.Operation{
 						OperationID: "ListBookEdition",
 					},
 				},
-				"/publishers/{publisher}/books/{book}/editions/{book-edition}": {
+				"/publishers/{publisher_id}/books/{book_id}/editions/{book_edition_id}": {
 					Get: &openapi.Operation{
 						OperationID: "GetBookEdition",
 					},
@@ -306,13 +306,13 @@ func TestGenerateParentPatternsWithParams(t *testing.T) {
 		{
 			name: "with pattern elements",
 			resource: &Resource{
-				patternElems: []string{"databases", "{database}", "tables", "{table}"},
+				patternElems: []string{"databases", "{database_id}", "tables", "{table_id}"},
 				Singular:     "table",
 			},
 			wantCollection: "/tables",
 			wantPathParams: &[]PathWithParams{
 				{
-					Pattern: "/databases/{database}",
+					Pattern: "/databases/{database_id}",
 					Params: []openapi.Parameter{
 						{
 							In:       "path",
@@ -332,7 +332,7 @@ func TestGenerateParentPatternsWithParams(t *testing.T) {
 		{
 			name: "with pattern elements no nesting",
 			resource: &Resource{
-				patternElems: []string{"databases", "{database}"},
+				patternElems: []string{"databases", "{database_id}"},
 				Singular:     "database",
 			},
 			wantCollection: "/databases",
@@ -359,7 +359,7 @@ func TestGenerateParentPatternsWithParams(t *testing.T) {
 			wantCollection: "/tables",
 			wantPathParams: &[]PathWithParams{
 				{
-					Pattern: "/databases/{database}",
+					Pattern: "/databases/{database_id}",
 					Params: []openapi.Parameter{
 						{
 							In:       "path",
@@ -397,7 +397,7 @@ func TestGenerateParentPatternsWithParams(t *testing.T) {
 			wantCollection: "/tables",
 			wantPathParams: &[]PathWithParams{
 				{
-					Pattern: "/accounts/{account}/databases/{database}",
+					Pattern: "/accounts/{account_id}/databases/{database_id}",
 					Params: []openapi.Parameter{
 						{
 							In:       "path",
@@ -519,8 +519,8 @@ func TestLongRunningOperation(t *testing.T) {
 	}
 
 	resource := &Resource{
-		Singular: "testResource",
-		Plural:   "testResources",
+		Singular: "test_resource",
+		Plural:   "test_resources",
 		Schema: &openapi.Schema{
 			Type: "object",
 			Properties: map[string]openapi.Schema{
@@ -535,7 +535,7 @@ func TestLongRunningOperation(t *testing.T) {
 		Name:      "Test API",
 		ServerURL: "https://api.example.com",
 		Resources: map[string]*Resource{
-			"testResource": resource,
+			"test_resource": resource,
 		},
 	}
 
@@ -543,7 +543,7 @@ func TestLongRunningOperation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, openAPI)
 
-	path := "/testResources/{testResource}:longRunningTest"
+	path := "/test_resources/{test_resource_id}:longRunningTest"
 	operation := openAPI.Paths[path].Post
 	assert.NotNil(t, operation, "Expected POST operation for long-running test")
 	assert.Equal(t, AEP_OPERATION_REF,
@@ -555,8 +555,8 @@ func TestLongRunningOperation(t *testing.T) {
 
 func TestLongRunningMethods(t *testing.T) {
 	resource := &Resource{
-		Singular: "testResource",
-		Plural:   "testResources",
+		Singular: "test_resource",
+		Plural:   "test_resources",
 		Schema: &openapi.Schema{
 			Type: "object",
 			Properties: map[string]openapi.Schema{
@@ -584,7 +584,7 @@ func TestLongRunningMethods(t *testing.T) {
 		Name:      "Test API",
 		ServerURL: "https://api.example.com",
 		Resources: map[string]*Resource{
-			"testResource": resource,
+			"test_resource": resource,
 		},
 	}
 
@@ -593,7 +593,7 @@ func TestLongRunningMethods(t *testing.T) {
 	assert.NotNil(t, openAPI)
 
 	// Validate CreateMethod
-	createPath := "/testResources"
+	createPath := "/test_resources"
 	createOperation := openAPI.Paths[createPath].Post
 	assert.NotNil(t, createOperation, "Expected POST operation for CreateMethod")
 	assert.Equal(t, AEP_OPERATION_REF,
@@ -603,7 +603,7 @@ func TestLongRunningMethods(t *testing.T) {
 		"Expected XAEPLongRunningOperation to be set for CreateMethod")
 
 	// Validate ApplyMethod
-	applyPath := "/testResources/{testResource}"
+	applyPath := "/test_resources/{test_resource_id}"
 	applyOperation := openAPI.Paths[applyPath].Put
 	assert.NotNil(t, applyOperation, "Expected PUT operation for ApplyMethod")
 	assert.Equal(t, AEP_OPERATION_REF,

--- a/pkg/api/resource.go
+++ b/pkg/api/resource.go
@@ -97,7 +97,7 @@ func CollectionName(r *Resource) string {
 		parent := r.ParentResources()[0].Singular
 		// if collectionName has a prefix of parent, remove it
 		if strings.HasPrefix(collectionName, parent) {
-			collectionName = strings.TrimPrefix(collectionName, parent+"-")
+			collectionName = strings.TrimPrefix(collectionName, parent+"_")
 		}
 	}
 	return collectionName
@@ -108,8 +108,7 @@ func CollectionName(r *Resource) string {
 func (r *Resource) PatternElems() []string {
 	if len(r.patternElems) == 0 {
 		// Base pattern without params
-		patternElems := []string{CollectionName(r), fmt.Sprintf("{%s}", r.Singular)}
-		// pattern := fmt.Sprintf("%v/{%v}", CollectionName(r), r.Singular)
+		patternElems := []string{CollectionName(r), fmt.Sprintf("{%s_id}", r.Singular)}
 		if len(r.Parents) > 0 {
 			patternElems = append(
 				r.ParentResources()[0].PatternElems(),

--- a/pkg/api/testutils.go
+++ b/pkg/api/testutils.go
@@ -119,10 +119,10 @@ func ExampleAPI() *API {
 	}
 	publisher.Children = append(publisher.Children, tome)
 
-	// Create book-edition resource
+	// Create book_edition resource
 	bookEdition := &Resource{
-		Singular:        "book-edition",
-		Plural:          "book-editions",
+		Singular:        "book_edition",
+		Plural:          "book_editions",
 		Parents:         []string{"book"},
 		parentResources: []*Resource{book},
 		Schema: &openapi.Schema{
@@ -157,7 +157,7 @@ func ExampleAPI() *API {
 		},
 		Resources: map[string]*Resource{
 			"book":         book,
-			"book-edition": bookEdition,
+			"book_edition": bookEdition,
 			"publisher":    publisher,
 			"operation":    OperationResourceWithDefaults(),
 			"tome":         tome,

--- a/pkg/cases/cases.go
+++ b/pkg/cases/cases.go
@@ -64,6 +64,25 @@ func KebabToPascalCase(s string) string {
 	return UpperFirst(KebabToCamelCase(s))
 }
 
+func SnakeToPascalCase(s string) string {
+	return UpperFirst(SnakeToCamelCase(s))
+}
+
+func SnakeToCamelCase(s string) string {
+	parts := strings.Split(s, "_")
+	for i := range parts {
+		if len(parts[i]) > 0 {
+			parts[i] = strings.ToUpper(string(parts[i][0])) + parts[i][1:]
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+func PascalToSnakeCase(s string) string {
+	asKebab := PascalCaseToKebabCase(s)
+	return KebabToSnakeCase(asKebab)
+}
+
 func KebabToSnakeCase(s string) string {
 	return strings.ReplaceAll(s, "-", "_")
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -60,7 +60,7 @@ func TestCreateWithUserSpecifiedId(t *testing.T) {
 	}
 
 	parameters := map[string]string{
-		"publisher": "my-pub",
+		"publisher_id": "my-pub",
 	}
 
 	// Call the Create method
@@ -151,7 +151,7 @@ func TestList(t *testing.T) {
 	ctx := context.Background()
 
 	parameters := map[string]string{
-		"publisher": "my-pub",
+		"publisher_id": "my-pub",
 	}
 
 	c := NewClient(http.DefaultClient)

--- a/pkg/proto/proto.go
+++ b/pkg/proto/proto.go
@@ -143,7 +143,7 @@ func toProtoServiceName(serviceName string) string {
 }
 
 func toMessageName(resource string) string {
-	return cases.KebabToCamelCase(resource)
+	return cases.SnakeToCamelCase(resource)
 }
 
 func getSortedResources(a *api.API) []*api.Resource {


### PR DESCRIPTION
The aep guidance is to add the _id suffix
on all path elements. For consistency, adding the _id
suffix to the pattern as well.

Making this change also required propagating the snake_case
convention to the resource singular and API conversion as well -
without doing so, conversion logic is necessary to extract and generate
the appropriate paths. 

This is aligned with the work to align with snake case
across the board: https://github.com/aep-dev/aeps/discussions/320

This change is being made in lockstep with
https://github.com/aep-dev/aeps/pull/321 to update the guidance.